### PR TITLE
Update Dockerfile user permissions on /tmp/export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ WORKDIR /tmp/config
 # use sample config as fallback
 ADD config_sample/config.py /tmp/config/config.py
 
-RUN useradd -ms /bin/bash bob
-USER bob
+RUN useradd -ms /bin/bash overviewer-mc
+RUN chown overviewer-mc:overviewer-mc /tmp/export
+USER overviewer-mc
 
 #eg. "--genpoi"
 ENV overviewerParams=""


### PR DESCRIPTION
Apply chown to /tmp/export with created user
 - Allows using named containers through docker-compose without forcing user back to root
Change created user to "overviewer-mc"